### PR TITLE
Point DNS at ELB, update health checks

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,34 @@
+# See https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer.html
+
+# The DNS record for `mongoose-footprints.com` doesn't need to be managed by
+# Terraform, but we can fetch info about it using the `data` directive
+data "aws_route53_zone" "footprints" {
+  name         = "mongoose-footprints.com."
+  private_zone = false
+}
+
+# Route requests to `mongoose-footprints.com` to our ELB
+resource "aws_route53_record" "footprints_elb_root" {
+  zone_id = "${data.aws_route53_zone.footprints.zone_id}"
+  name    = "${data.aws_route53_zone.footprints.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.blue_green_elb.dns_name}"
+    zone_id                = "${aws_lb.blue_green_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+# Route requests to `www.mongoose-footprints.com` to our ELB
+resource "aws_route53_record" "footprints_elb_www" {
+  zone_id = "${data.aws_route53_zone.footprints.zone_id}"
+  name    = "www.${data.aws_route53_zone.footprints.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.blue_green_elb.dns_name}"
+    zone_id                = "${aws_lb.blue_green_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/terraform/elb.tf
+++ b/terraform/elb.tf
@@ -55,6 +55,11 @@ resource "aws_lb_target_group" "blue_elb_target_group" {
   target_type = "instance"
   vpc_id      = "${aws_vpc.blue_green_vpc.id}"
 
+  health_check {
+    port = 80
+    matcher = "200,301,302"
+  }
+
   tags {
     Name = "blue-elb-target-group"
   }
@@ -75,6 +80,11 @@ resource "aws_lb_target_group" "green_elb_target_group" {
   protocol    = "HTTP"
   target_type = "instance"
   vpc_id      = "${aws_vpc.blue_green_vpc.id}"
+
+  health_check {
+    port = 80
+    matcher = "200,301,302"
+  }
 
   tags {
     Name = "green-elb-target-group"

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,5 +1,5 @@
 resource "aws_db_instance" "footprints" {
-  identifier           = "footprints-db-blue-green"
+  identifier           = "footprints"
   allocated_storage    = 20
   storage_type         = "gp2"
   engine               = "mysql"
@@ -19,13 +19,13 @@ resource "aws_db_instance" "footprints" {
 
   # Prevent deletion of the database on Terraform teardown
   deletion_protection       = true
-  final_snapshot_identifier = "footprints-db-blue-green-final-snapshot"
+  final_snapshot_identifier = "footprints-db-final-snapshot"
   copy_tags_to_snapshot     = true
 
   vpc_security_group_ids = ["${aws_security_group.footprints_db_security_group.id}"]
 
   tags {
-    Name = "footprints_db_blue_green"
+    Name = "footprints_db"
   }
 
   depends_on = [


### PR DESCRIPTION
This PR updates the DNS configuration for the `mongoose-footprints.com.` public zone to direct traffic to our ELB. After testing this myself, I can confirm that running the provisioning script, and then running the Capistrano deploy task, successfully deploys the application and makes it available at `mongoose-footprints.com`.