### PR TITLE
Use shared SSH keys for auth

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -65,6 +65,6 @@ EOF
 
 cd ./../ansible
 
-ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ansible_hosts playbook.yml;
+ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook --private-key=~/.ssh/mongeese-footprints -i ansible_hosts playbook.yml;
 
 echo "Visit the URL http://$blue_green_elb_domain to see the current active state of your application.";

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,6 @@
 variable "public_key_path" {
   type        = "string"
+  default     = "~/.ssh/mongeese-footprints.pub"
   description = <<EOF
 Path to the SSH public key to be used for authentication.
 Create this SSH keypair BEFORE provisioning or you will not be able to connect.
@@ -10,6 +11,7 @@ EOF
 
 variable "private_key_path" {
   type        = "string"
+  default     = "~/.ssh/mongeese-footprints"
   description = <<EOF
 Path to the SSH private key to be used for authentication.
 Create this SSH keypair BEFORE provisioning or you will not be able to connect.


### PR DESCRIPTION
This PR makes use of the shared keys we have on Slack for SSH auth for Terraform, Ansible, and EC2 access.

@bartboy011 	@Alexi5 	@rionner 	please review