### PR TITLE
Use the correct SSH public key to match Terraform

### DIFF
--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -28,4 +28,4 @@
   authorized_key:
     user: deployer
     state: present
-    key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
+    key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/mongeese-footprints.pub') }}"


### PR DESCRIPTION
I overlooked a spot where I needed to point to the new SSH keypair we're sharing for SSH access and provisioning. This fixes that oversight.