### PR TITLE
Set up SSL traffic to production site

### DIFF
--- a/terraform/ssl.tf
+++ b/terraform/ssl.tf
@@ -1,0 +1,7 @@
+# Look up the data for our SSL certificate for
+# *.mongoose-footprints.com. Terraform cannot manage
+# the cert directly, but can look it up for reference.
+data "aws_acm_certificate" "footprints_production" {
+  domain   = "*.mongoose-footprints.com"
+  statuses = ["ISSUED"]
+}


### PR DESCRIPTION
Does three things:
	- Allows the ALB to receive TCP traffic at port 443 from any IP address on the internet 
	- Changes the existing blue/green ALB listener from port 80 to port 443 and gives it a cert
	- Adds a listener to port 80 that will redirect traffic to port 443