### PR TITLE
Change blue green to staging production

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ following dependencies installed:
 - [Terraform](https://www.terraform.io/downloads.html)
 - [The AWS CLI tool](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
-- [jq](https://stedolan.github.io/jq/) 
+- [jq](https://stedolan.github.io/jq/)
+- `ansible-galaxy install rvm.ruby`
 
 ## Getting Started
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -10,7 +10,7 @@
     - nginx
     - mysql
     - vim
-    - { role: rvm_io.ruby,
+    - { role: rvm.ruby,
         tags: ruby,
         become: yes,
 

--- a/ansible/roles/nginx/templates/footprints.j2
+++ b/ansible/roles/nginx/templates/footprints.j2
@@ -1,8 +1,26 @@
 upstream footprints { server unix:/var/www/footprints/current/tmp/sockets/unicorn.sock fail_timeout=0; }
 
 server {
+  listen *:80;
+  server_name staging.mongoose-footprints.com;
+  root /var/www/footprints/current/public;
+
+  proxy_set_header X-Real-IP  $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header Host $http_host;
+  proxy_hide_header X-Runtime;
+  proxy_redirect off;
+
+  try_files $uri @rails;
+  location @rails { proxy_pass http://footprints; }
+  location @rails_expiry { expires 1y; proxy_pass http://footprints; }
+
+  location ~ ^/(images|javascripts|stylesheets)/  { try_files $uri @rails_expiry; }
+}
+
+server {
   server_name mongoose-footprints.com;
-  rewrite ^(.*) http://www.mongoose-footprints.com$1 permanent;
+  rewrite ^(.*) https://www.mongoose-footprints.com$1 permanent;
 }
 
 server {

--- a/bin/switch
+++ b/bin/switch
@@ -36,9 +36,9 @@ The $active_target_group group is active! Switching to the $new_target_group gro
 
 	cd terraform;
 
-	blue_green_elb_domain=$(terraform output blue_green_elb_domain);
+	production_elb_domain=$(terraform output production_elb_domain);
 
-	echo "Visit the URL http://$blue_green_elb_domain to see the current active sate of your application.";
+	echo "Visit the URL http://$production_elb_domain to see the current active sate of your application.";
 }
 
 switch

--- a/bin/up
+++ b/bin/up
@@ -32,7 +32,7 @@ blue_ec2_ip=$(terraform output blue_ec2_ip);
 
 green_ec2_ip=$(terraform output green_ec2_ip);
 
-blue_green_elb_domain=$(terraform output blue_green_elb_domain);
+production_elb_domain=$(terraform output production_elb_domain);
 
 # Export the database credentials for placing in the template for db config
 database_host=$(terraform output footprints_db_host);
@@ -67,4 +67,4 @@ cd ./../ansible
 
 ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook --private-key=~/.ssh/mongeese-footprints -i ansible_hosts playbook.yml;
 
-echo "Visit the URL http://$blue_green_elb_domain to see the current active state of your application.";
+echo "Visit the URL http://$production_elb_domain to see the current active state of your application.";

--- a/lib/describe-load-balancer.sh
+++ b/lib/describe-load-balancer.sh
@@ -6,7 +6,7 @@ function describe_load_balancer()
 {
     cd ./terraform;
 
-    load_balancer_name=$(terraform output blue_green_elb_name);
+    load_balancer_name=$(terraform output production_elb_name);
 
     aws elbv2 describe-load-balancers --names "$load_balancer_name";
 }

--- a/lib/get-current-target-group.sh
+++ b/lib/get-current-target-group.sh
@@ -6,7 +6,7 @@ function get_current_target_group()
 {
     cd ./terraform;
 
-    load_balancer_arn=$(terraform output blue_green_elb_arn);
+    load_balancer_arn=$(terraform output production_elb_arn);
 
     aws elbv2 describe-listeners --load-balancer-arn "$load_balancer_arn" \
         | jq -r '.Listeners[0].DefaultActions[0].TargetGroupArn'

--- a/lib/get-listener-arn.sh
+++ b/lib/get-listener-arn.sh
@@ -6,7 +6,7 @@ function get_listener_arn()
 {
     cd ./terraform;
 
-    load_balancer_arn=$(terraform output blue_green_elb_arn);
+    load_balancer_arn=$(terraform output production_elb_arn);
 
     aws elbv2 describe-listeners --load-balancer-arn "$load_balancer_arn" \
         | jq -r '.Listeners[0].ListenerArn'

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -14,8 +14,8 @@ resource "aws_route53_record" "footprints_elb_root" {
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.blue_green_elb.dns_name}"
-    zone_id                = "${aws_lb.blue_green_elb.zone_id}"
+    name                   = "${aws_lb.production_elb.dns_name}"
+    zone_id                = "${aws_lb.production_elb.zone_id}"
     evaluate_target_health = true
   }
 }
@@ -27,8 +27,8 @@ resource "aws_route53_record" "footprints_elb_www" {
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.blue_green_elb.dns_name}"
-    zone_id                = "${aws_lb.blue_green_elb.zone_id}"
+    name                   = "${aws_lb.production_elb.dns_name}"
+    zone_id                = "${aws_lb.production_elb.zone_id}"
     evaluate_target_health = true
   }
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -34,9 +34,9 @@ resource "aws_route53_record" "footprints_elb_www" {
 }
 
 # Route requests to the staging elb
-resource "aws_route53_record" "staging_elb_www" {
+resource "aws_route53_record" "staging_elb_staging" {
   zone_id = "${data.aws_route53_zone.footprints.zone_id}"
-  name    = "www.${data.aws_route53_zone.footprints.name}"
+  name    = "staging.${data.aws_route53_zone.footprints.name}"
   type    = "A"
 
   alias {

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -32,3 +32,16 @@ resource "aws_route53_record" "footprints_elb_www" {
     evaluate_target_health = true
   }
 }
+
+# Route requests to the staging elb
+resource "aws_route53_record" "staging_elb_www" {
+  zone_id = "${data.aws_route53_zone.footprints.zone_id}"
+  name    = "www.${data.aws_route53_zone.footprints.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.staging_elb.dns_name}"
+    zone_id                = "${aws_lb.staging_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -53,7 +53,7 @@ resource "aws_instance" "green_ec2" {
 # Provides security group configuration for EC2 instances (eg. SSH and HTTP)
 resource "aws_security_group" "blue_green_instance_security_group" {
   name        = "blue_green_instance_security_group"
-  vpc_id      = "${aws_vpc.blue_green_vpc.id}"
+  vpc_id      = "${aws_vpc.production_and_staging_vpc.id}"
 
   # SSH access from anywhere
   ingress {
@@ -76,7 +76,7 @@ resource "aws_security_group" "blue_green_instance_security_group" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["${aws_vpc.blue_green_vpc.cidr_block}"]
+    cidr_blocks = ["${aws_vpc.production_and_staging_vpc.cidr_block}"]
   }
 
   # Outbound internet access
@@ -91,7 +91,7 @@ resource "aws_security_group" "blue_green_instance_security_group" {
 # Create the subnet for the "blue" EC2
 resource "aws_subnet" "blue_subnet" {
   availability_zone       = "us-east-1b"
-  vpc_id                  = "${aws_vpc.blue_green_vpc.id}"
+  vpc_id                  = "${aws_vpc.production_and_staging_vpc.id}"
   cidr_block              = "10.0.1.0/24"
 
   # Make sure EC2 instances added to this subnet get public IP addresses
@@ -105,7 +105,7 @@ resource "aws_subnet" "blue_subnet" {
 # Create the subnet for the "green" EC2
 resource "aws_subnet" "green_subnet" {
   availability_zone       = "us-east-1a"
-  vpc_id                  = "${aws_vpc.blue_green_vpc.id}"
+  vpc_id                  = "${aws_vpc.production_and_staging_vpc.id}"
   cidr_block              = "10.0.2.0/24"
 
   # Make sure EC2 instances added to this subnet get public IP addresses

--- a/terraform/elb.tf
+++ b/terraform/elb.tf
@@ -22,12 +22,13 @@ resource "aws_lb" "staging_elb" {
   internal			 = false
   load_balancer_type = "application"
   security_groups	 = ["${aws_security_group.blue_green_elb_security_group.id}"]
-  subnets			 = ["${aws_subnet.blue_subnet.id}",
-  						"${aws_subnet.green_subnet.id}"
+  subnets			 = [
+    "${aws_subnet.blue_subnet.id}",
+    "${aws_subnet.green_subnet.id}"
   ]
-  
+
   idle_timeout		 = 400
-  
+
   tags {
     Name = "staging-elb"
   }
@@ -96,7 +97,7 @@ resource "aws_lb_target_group" "blue_elb_target_group" {
 # Attach blue target group to the staging instance
 resource "aws_lb_target_group_attachment" "blue_elb_target_group_attachment" {
   target_group_arn = "${aws_lb_target_group.blue_elb_target_group.arn}"
-  target_id        = "${aws_lb.staging_elb.id}"
+  target_id        = "${aws_instance.blue_ec2.id}"
   port             = 80
 }
 
@@ -126,7 +127,7 @@ resource "aws_lb_target_group_attachment" "green_elb_target_group_attachment" {
   port             = 80
 }
 
-# Initially configure our load balancer to forward HTTP requests on port 80 to
+# Initially configure our load balancer to forward HTTPS requests on port 443 to
 # the "green" target group (and thus the "green" EC2)
 resource "aws_lb_listener" "blue_green_elb_listener" {
   "default_action" {
@@ -141,7 +142,23 @@ resource "aws_lb_listener" "blue_green_elb_listener" {
   ssl_policy = "ELBSecurityPolicy-2016-08"
 }
 
-resource "aws_alb_listener" "https_lb_redirect" {
+# And configure our staging load balancer to forward HTTPS requests on port 443 to
+# the "green" target group (and thus the "green" EC2)
+resource "aws_lb_listener" "staging_elb_listener" {
+  "default_action" {
+    type = "forward"
+    target_group_arn = "${aws_lb_target_group.blue_elb_target_group.arn}"
+  }
+
+  load_balancer_arn = "${aws_lb.staging_elb.arn}"
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn = "${data.aws_acm_certificate.footprints_production.arn}"
+  ssl_policy = "ELBSecurityPolicy-2016-08"
+}
+
+# Force all non-port 443 traffic (meaning HTTP) to redirect to that port
+resource "aws_alb_listener" "https_blue_green_lb_redirect" {
   "default_action" {
     type = "redirect"
 
@@ -153,5 +170,20 @@ resource "aws_alb_listener" "https_lb_redirect" {
   }
 
   load_balancer_arn = "${aws_lb.blue_green_elb.arn}"
+  port = 80
+}
+
+resource "aws_alb_listener" "https_staging_lb_redirect" {
+  "default_action" {
+    type = "redirect"
+
+    redirect {
+      port = "443"
+      protocol = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  load_balancer_arn = "${aws_lb.staging_elb.arn}"
   port = 80
 }

--- a/terraform/elb.tf
+++ b/terraform/elb.tf
@@ -16,6 +16,25 @@ resource "aws_lb" "blue_green_elb" {
   }
 }
 
+# Create ELB for staging instance
+resource "aws_lb" "staging_elb" {
+  name				 = "staging-elb"
+  internal			 = false
+  load_balancer_type = "application"
+  security_groups	 = ["${aws_security_group.blue_green_elb_security_group.id}"]
+  subnets			 = ["${aws_subnet.blue_subnet.id}",
+  						"${aws_subnet.green_subnet.id}"
+  ]
+  
+  idle_timeout		 = 400
+  
+  tags {
+    Name = "staging-elb"
+  }
+}
+
+# Security for the staging 
+
 # Provides security group configuration for the ELB itself (eg. internet access)
 resource "aws_security_group" "blue_green_elb_security_group" {
   name        = "blue_green_elb_security_group"
@@ -73,10 +92,11 @@ resource "aws_lb_target_group" "blue_elb_target_group" {
   }
 }
 
-# Attach the EC2 instance for the "blue" EC2 instance to the blue target group
+# Old: Attach the EC2 instance for the "blue" EC2 instance to the blue target group
+# Attach blue target group to the staging instance
 resource "aws_lb_target_group_attachment" "blue_elb_target_group_attachment" {
   target_group_arn = "${aws_lb_target_group.blue_elb_target_group.arn}"
-  target_id        = "${aws_instance.blue_ec2.id}"
+  target_id        = "${aws_lb.staging_elb.id}"
   port             = 80
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,6 +23,6 @@ provider "aws" {
 
 # Set up the public SSH key we should use for interacting with the EC2 instances
 resource "aws_key_pair" "auth" {
-  key_name   = "blue_green_key_pair"
+  key_name   = "production_and_staging_key_pair"
   public_key = "${file(var.public_key_path)}"
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -9,28 +9,28 @@ output "green_ec2_ip" {
 }
 
 # Output the domain name of the load balancer
-output "blue_green_elb_domain" {
-  value = "${aws_lb.blue_green_elb.dns_name}"
+output "production_elb_domain" {
+  value = "${aws_lb.production_elb.dns_name}"
 }
 
 # Output the ARN of the load balancer
-output "blue_green_elb_arn" {
-  value = "${aws_lb.blue_green_elb.arn}"
+output "production_elb_arn" {
+  value = "${aws_lb.production_elb.arn}"
 }
 
 # Output the name of the load balancer
-output "blue_green_elb_name" {
-  value = "${aws_lb.blue_green_elb.name}"
+output "production_elb_name" {
+  value = "${aws_lb.production_elb.name}"
 }
 
 # Output the ARN of the "blue" ELB target group
 output "blue_target_group_arn" {
-  value = "${aws_lb_target_group.blue_elb_target_group.arn}"
+  value = "${aws_lb_target_group.staging_elb_target_group.arn}"
 }
 
 # Output the ARN of the "green" ELB target group
 output "green_target_group_arn" {
-  value = "${aws_lb_target_group.green_elb_target_group.arn}"
+  value = "${aws_lb_target_group.production_elb_target_group.arn}"
 }
 
 # Output the Footprints DB's hostname

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -36,7 +36,7 @@ resource "aws_db_instance" "footprints" {
 
 resource "aws_security_group" "footprints_db_security_group" {
   name   = "footprints_db_security_group"
-  vpc_id = "${aws_vpc.blue_green_vpc.id}"
+  vpc_id = "${aws_vpc.production_and_staging_vpc.id}"
 
   # MySQL access from the EC2 subnets
   ingress {

--- a/terraform/routing.tf
+++ b/terraform/routing.tf
@@ -1,6 +1,6 @@
 # The internet gateway allows our VPC to connect to the public internet
 resource "aws_internet_gateway" "blue_green_internet_gateway" {
-  vpc_id = "${aws_vpc.blue_green_vpc.id}"
+  vpc_id = "${aws_vpc.production_and_staging_vpc.id}"
 
   tags {
     Name = "blue-green-internet-gateway"
@@ -10,7 +10,7 @@ resource "aws_internet_gateway" "blue_green_internet_gateway" {
 # Define the routing configuration so that the internet gateway can talk to the
 # whole public internet (CIDR 0.0.0.0/0)
 resource "aws_route" "blue_green_internet_access_route" {
-  route_table_id         = "${aws_vpc.blue_green_vpc.main_route_table_id}"
+  route_table_id         = "${aws_vpc.production_and_staging_vpc.main_route_table_id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.blue_green_internet_gateway.id}"
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,10 +1,10 @@
 # Configure our VPC
-resource "aws_vpc" "blue_green_vpc" {
+resource "aws_vpc" "production_and_staging_vpc" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags {
-    Name = "blue-green-vpc"
+    Name = "production-and-staging-vpc"
   }
 }


### PR DESCRIPTION
Depends on #6, simply updates config files to use production and staging rather than blue green nomenclature, except for EC2 instance names.

#### NOTE: Once merged I'll begin running the application for both Terraform and Ansible.