### PR TITLE
Must depend on array position for now

### DIFF
--- a/lib/get-current-target-group.sh
+++ b/lib/get-current-target-group.sh
@@ -9,5 +9,5 @@ function get_current_target_group()
     load_balancer_arn=$(terraform output blue_green_elb_arn);
 
     aws elbv2 describe-listeners --load-balancer-arn "$load_balancer_arn" \
-        | jq -r '.Listeners[0].DefaultActions[0].TargetGroupArn'
+        | jq -r '.Listeners[1].DefaultActions[0].TargetGroupArn'
 }


### PR DESCRIPTION
This PR hardcodes `get_current_target_group.sh` to reference the second element in the array for the aws call to list the active listeners.

This is temporary; we intend to make these scripts more intelligent so that they do not depend on array ordering.

See: https://trello.com/c/fGPmMecI/31-make-bluegreenipclient-work-regardless-of-array-order